### PR TITLE
compose hero visual as one dashboard frame + 2-state color mode toggle

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -114,46 +114,112 @@
 }
 
 /* ---------------------------------------------------------------- */
-/* Hero visual — entity panel motif (purely decorative)              */
+/* Hero visual — single dashboard frame (purely decorative)          */
 /* ---------------------------------------------------------------- */
 .heroVisual {
   position: relative;
-  min-height: 22rem;
 }
 
-.visPanel {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: min(19.5rem, 88%);
+.visDash {
   background: var(--hr-surface);
   border: 1px solid var(--hr-border);
   border-radius: 20px;
   box-shadow: var(--hr-shadow-lift);
-  padding: 1.4rem 1.5rem 1.6rem;
-  animation: visFloat 7s ease-in-out infinite alternate;
+  padding: 1.25rem 1.25rem 1.4rem;
 }
 
-.visPanelTop {
+.visDashBar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.35rem;
+  padding-bottom: 1rem;
+  margin-bottom: 1.1rem;
+  border-bottom: 1px solid var(--hr-border);
+}
+
+.visDashTitle {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.visDashTitle span {
+  display: block;
+  height: 10px;
+  border-radius: 5px;
+  background: var(--ifm-color-emphasis-300);
+}
+
+.visDashTitle span:first-child {
+  width: 7.5rem;
+}
+
+.visDashTitle span:last-child {
+  width: 4.5rem;
+  height: 8px;
+  background: var(--ifm-color-emphasis-200);
+}
+
+.visDashStatus {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.7rem;
+  border: 1px solid var(--hr-border);
+  border-radius: 999px;
+}
+
+.visDashStatus span {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #34d399;
+  box-shadow: 0 0 8px rgba(52, 211, 153, 0.6);
+}
+
+.visDashStatus::after {
+  content: '';
+  display: block;
+  width: 2.75rem;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--ifm-color-emphasis-200);
+}
+
+.visDashGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.9rem;
+}
+
+.visTile {
+  background: var(--hr-bg);
+  border: 1px solid var(--hr-border);
+  border-radius: 14px;
+  padding: 1rem 1.1rem 1.1rem;
+}
+
+.visTileTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.1rem;
 }
 
 .visOrb {
-  width: 54px;
-  height: 54px;
+  width: 42px;
+  height: 42px;
   border-radius: 50%;
   background: radial-gradient(circle at 34% 30%, #ffe9b0, #ffb020 62%, #f08c00);
   box-shadow:
-    0 0 24px rgba(255, 176, 32, 0.55),
-    0 0 64px rgba(255, 176, 32, 0.3);
+    0 0 18px rgba(255, 176, 32, 0.5),
+    0 0 48px rgba(255, 176, 32, 0.28);
 }
 
 .visToggle {
-  width: 48px;
-  height: 27px;
+  width: 42px;
+  height: 24px;
   border-radius: 999px;
   background: var(--hr-brand);
   display: flex;
@@ -163,24 +229,23 @@
 }
 
 .visToggle span {
-  width: 21px;
-  height: 21px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   background: #fff;
-  transform: translateX(21px);
+  transform: translateX(18px);
   box-shadow: 0 1px 3px rgba(8, 47, 73, 0.4);
 }
 
 .visRows {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  margin-bottom: 1.5rem;
+  gap: 0.55rem;
 }
 
 .visRows span {
   display: block;
-  height: 10px;
+  height: 9px;
   border-radius: 5px;
   background: var(--ifm-color-emphasis-200);
 }
@@ -191,6 +256,24 @@
 
 .visRows span:last-child {
   width: 44%;
+}
+
+.visTileWide {
+  grid-column: span 2;
+}
+
+.visTileWide .visRows {
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 1.1rem;
+}
+
+.visTileWide .visRows span:first-child {
+  width: 34%;
+}
+
+.visTileWide .visRows span:last-child {
+  width: 18%;
 }
 
 .visSlider {
@@ -224,24 +307,11 @@
   box-shadow: 0 1px 4px rgba(8, 47, 73, 0.3);
 }
 
-.visGauge {
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  width: 11rem;
-  background: var(--hr-surface);
-  border: 1px solid var(--hr-border);
-  border-radius: 16px;
-  box-shadow: var(--hr-shadow);
-  padding: 1.1rem 1.1rem 1.2rem;
-  animation: visFloat 9s ease-in-out infinite alternate-reverse;
-}
-
 .visGaugeSvg {
   display: block;
-  width: 76px;
-  height: 76px;
-  margin: 0 auto 0.9rem;
+  width: 68px;
+  height: 68px;
+  margin: 0 auto 0.85rem;
   transform: rotate(-90deg);
 }
 
@@ -280,11 +350,6 @@
 .visGaugeRows span:last-child {
   width: 38%;
   margin: 0 auto;
-}
-
-@keyframes visFloat {
-  from { transform: translateY(0); }
-  to { transform: translateY(-9px); }
 }
 
 /* ---------------------------------------------------------------- */
@@ -608,7 +673,6 @@
   }
 
   .heroVisual {
-    min-height: 18rem;
     max-width: 26rem;
   }
 
@@ -676,11 +740,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .visPanel,
-  .visGauge {
-    animation: none;
-  }
-
   .featureCard,
   .primaryButton,
   .secondaryButton {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -78,20 +78,31 @@ function HeroSection() {
             </div>
           </div>
           <div className={styles.heroVisual} aria-hidden="true">
-            <div className={styles.visPanel}>
-              <div className={styles.visPanelTop}>
-                <div className={styles.visOrb} />
-                <div className={styles.visToggle}><span /></div>
+            <div className={styles.visDash}>
+              <div className={styles.visDashBar}>
+                <div className={styles.visDashTitle}><span /><span /></div>
+                <div className={styles.visDashStatus}><span /></div>
               </div>
-              <div className={styles.visRows}><span /><span /></div>
-              <div className={styles.visSlider}><span /></div>
-            </div>
-            <div className={styles.visGauge}>
-              <svg viewBox="0 0 72 72" className={styles.visGaugeSvg}>
-                <circle cx="36" cy="36" r="30" className={styles.visGaugeTrack} />
-                <circle cx="36" cy="36" r="30" className={styles.visGaugeArc} />
-              </svg>
-              <div className={styles.visGaugeRows}><span /><span /></div>
+              <div className={styles.visDashGrid}>
+                <div className={styles.visTile}>
+                  <div className={styles.visTileTop}>
+                    <div className={styles.visOrb} />
+                    <div className={styles.visToggle}><span /></div>
+                  </div>
+                  <div className={styles.visRows}><span /><span /></div>
+                </div>
+                <div className={styles.visTile}>
+                  <svg viewBox="0 0 72 72" className={styles.visGaugeSvg}>
+                    <circle cx="36" cy="36" r="30" className={styles.visGaugeTrack} />
+                    <circle cx="36" cy="36" r="30" className={styles.visGaugeArc} />
+                  </svg>
+                  <div className={styles.visGaugeRows}><span /><span /></div>
+                </div>
+                <div className={`${styles.visTile} ${styles.visTileWide}`}>
+                  <div className={styles.visRows}><span /><span /></div>
+                  <div className={styles.visSlider}><span /></div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/docs/src/theme/ColorModeToggle/index.tsx
+++ b/docs/src/theme/ColorModeToggle/index.tsx
@@ -1,0 +1,48 @@
+/**
+ * Swizzled 2-state color mode toggle.
+ *
+ * Docusaurus 3.6+ ships a 3-state toggle (light -> dark -> system) when
+ * respectPrefersColorScheme is on. We want the classic behavior instead:
+ * default to the system scheme, show the effective mode's icon, and store an
+ * explicit preference the first time the visitor clicks.
+ */
+import React from 'react';
+import clsx from 'clsx';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import {useColorMode} from '@docusaurus/theme-common';
+import IconLightMode from '@theme/Icon/LightMode';
+import IconDarkMode from '@theme/Icon/DarkMode';
+import type {Props} from '@theme/ColorModeToggle';
+import styles from './styles.module.css';
+
+function ColorModeToggle({className, buttonClassName, onChange}: Props): React.JSX.Element {
+  const isBrowser = useIsBrowser();
+  // Effective mode (resolves the system preference); `value` from the navbar
+  // wrapper is the stored *choice* and is null until the visitor picks one.
+  const {colorMode} = useColorMode();
+  const next = colorMode === 'dark' ? 'light' : 'dark';
+
+  return (
+    <div className={clsx(styles.toggle, className)}>
+      <button
+        className={clsx(
+          'clean-btn',
+          styles.toggleButton,
+          !isBrowser && styles.toggleButtonDisabled,
+          buttonClassName,
+        )}
+        type="button"
+        onClick={() => onChange(next)}
+        disabled={!isBrowser}
+        title={`Switch to ${next} mode`}
+        aria-label={`Switch to ${next} mode`}>
+        {/* Both icons render; CSS keyed on the html[data-theme] attribute set
+            by the pre-hydration script shows the effective one. */}
+        <IconLightMode aria-hidden className={clsx(styles.toggleIcon, styles.lightToggleIcon)} />
+        <IconDarkMode aria-hidden className={clsx(styles.toggleIcon, styles.darkToggleIcon)} />
+      </button>
+    </div>
+  );
+}
+
+export default React.memo(ColorModeToggle);

--- a/docs/src/theme/ColorModeToggle/styles.module.css
+++ b/docs/src/theme/ColorModeToggle/styles.module.css
@@ -1,0 +1,34 @@
+.toggle {
+  width: 2rem;
+  height: 2rem;
+}
+
+.toggleButton {
+  -webkit-tap-highlight-color: transparent;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  transition: background var(--ifm-transition-fast);
+}
+
+.toggleButton:hover {
+  background: var(--ifm-color-emphasis-200);
+}
+
+.toggleIcon {
+  display: none;
+}
+
+/* Show the effective mode's icon, resolved from the html[data-theme]
+   attribute so it is correct before React hydrates. */
+:global([data-theme='light']) .lightToggleIcon,
+:global([data-theme='dark']) .darkToggleIcon {
+  display: initial;
+}
+
+.toggleButtonDisabled {
+  cursor: not-allowed;
+}


### PR DESCRIPTION
Two items from Derrick's homepage review:

- Hero right side: the two floating panels are replaced by a single anchored dashboard frame (header bar with status pill, light tile with toggle, sensor gauge tile, full-width thermostat slider) so it reads as a dashboard you could build. Rendered homepage text is byte-identical; the 640px media query still hides the visual on mobile.
- Color mode toggle: swizzled ColorModeToggle down from the 3-state cycle (light/dark/system) to the classic behavior: default to the system scheme, show the effective mode's icon (correct before hydration via html[data-theme] CSS), and store an explicit preference on first click. Verified with clean profiles under emulated system-dark and system-light: correct first-paint icon, first click flips to the opposite mode and persists it.