### PR TITLE
dedupe marketing points into six distinct claims + make mock mode honor them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Mock mode now transitions media player state (play/pause/stop, volume, mute, source, shuffle, repeat, power) and legacy vacuum power (`turn_on`/`turn_off`); `media_player.toggle` correctly acts as a power toggle
+
 ## [1.0.0] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,16 +8,12 @@ A React library for building custom Home Assistant interfaces. Headless componen
 
 ## Features
 
-- **Headless & Unstyled** - Use with any UI library or custom CSS
-- **Easy Real-time Updates** - One managed WebSocket connection shared by every hook and component
-- **Optimized Re-renders** - Components only re-render when their entity data changes
-- **Full TypeScript Support** - Complete type definitions for all supported entities
-- **OAuth & Token Auth** - Flexible authentication with connection state tracking
-- **External Transports** - Keep Home Assistant authentication server-side for kiosks and gateway-backed apps
-- **Error Handling** - Typed errors with optional automatic retry for network failures
-- **Mock Mode** - Develop and test without a live Home Assistant instance
-- **17 Entity Types** - Lights, climate, alarms, cameras, media players, sensors, and more
-- **Camera Streaming** - HLS and MJPEG stream support with static images
+- **17 Entity Types** - Lights, climate, cameras, media players, alarm panels, and twelve more, fully typed, with `supports*` capability flags and `callService` for everything else
+- **Hooks or Components** - Every entity works as a render-prop component or a hook; pick per component
+- **Headless & Unstyled** - No styles shipped; use any UI library or your own CSS
+- **Live State, No Plumbing** - One shared WebSocket keeps entities in sync, and components re-render only when their own entity changes; no Redux, no polling
+- **Auth Handled** - OAuth with automatic token refresh, long-lived tokens, or a server-side transport that keeps credentials out of the browser
+- **Mock Mode** - A simulated Home Assistant that answers service calls and state changes like the real one; develop and test without a live instance
 
 ## Installation
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -80,11 +80,10 @@ Both do the same thing. Pick whichever pattern you prefer.
 
 Subscriptions are managed for you:
 
-- **Shared subscriptions** - Components watching the same entity share a single WebSocket subscription
-- **Automatic cleanup** - Subscriptions are removed when a component unmounts
-- **Lazy loading** - Only entities you actually render get subscribed
-
-A dashboard with dozens of entity displays still runs over one WebSocket connection.
+- **One server subscription** - The store opens a single `state_changed` subscription and fans events out locally, no matter how many components are mounted
+- **Targeted notifications** - Each component registers for its own entity, so an event only wakes the components watching that entity
+- **Batched initial load** - Components mounting together share one `get_states` snapshot instead of sending a request each
+- **Automatic cleanup** - Registrations are removed when a component unmounts
 
 ## Next Steps
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -9,14 +9,14 @@ import styles from './index.module.css';
 
 const features = [
   {
-    title: 'Flexible API',
-    icon: '🪝',
-    description: 'Every entity works as a render-prop component or a hook. Pick per component. Both read from the same store.',
+    title: '17 Entity Types',
+    icon: '💡',
+    description: 'Lights, climate, cameras, media players, alarm panels, and twelve more, each fully typed. Capability flags like supportsBrightness keep your UI honest about what a device can do, and callService covers everything else Home Assistant exposes.',
   },
   {
-    title: 'Small and Fast',
-    icon: '⚡',
-    description: 'One WebSocket connection shared by every hook, and components only re-render when their own entity changes. Big dashboards stay fast.',
+    title: 'Hooks or Components',
+    icon: '🪝',
+    description: 'Every entity works as a render-prop component or a hook. Pick per component and mix freely. Both read from the same store.',
   },
   {
     title: 'Headless Design',
@@ -24,34 +24,34 @@ const features = [
     description: 'No styles shipped and no classes to override. Bring your own CSS, Tailwind, or component library.',
   },
   {
-    title: 'Real-time Updates',
-    icon: '🔌',
-    description: 'The provider owns the WebSocket. Entity states update the moment they change in Home Assistant, no polling.',
+    title: 'Live State, No Plumbing',
+    icon: '⚡',
+    description: 'One shared WebSocket keeps every entity in sync, and each component re-renders only when its own entity changes. No Redux, no context wiring, no polling.',
   },
   {
-    title: 'Built-in State Management',
-    icon: '📦',
-    description: 'No Redux and no context wiring. Entity state lives in the library and stays in sync with Home Assistant on its own.',
+    title: 'Auth Handled',
+    icon: '🔐',
+    description: 'OAuth with automatic token refresh, long-lived tokens, or your own server-side transport so credentials never reach the browser.',
   },
   {
-    title: 'Simple Service Calls',
-    icon: '🛠️',
-    description: 'Typed methods for common actions like turning on a light, plus callService for anything else Home Assistant exposes.',
+    title: 'Mock Mode',
+    icon: '🧪',
+    description: 'Flip one provider prop and develop against a built-in simulated Home Assistant that answers service calls and state updates like the real thing. Build, demo, and test without touching your house.',
   },
 ];
 
 const additionalFeatures = [
   {
-    title: 'Component Library',
-    description: 'Light, Switch, MediaPlayer, Climate, and more built-in components.',
+    title: 'Three Example Dashboards',
+    description: 'Complete vanilla CSS, shadcn/ui, and MUI builds in the repo.',
   },
   {
-    title: 'Fully Typed',
-    description: 'Complete type definitions for all entities and their properties.',
+    title: 'React 16.14+',
+    description: 'React is the only peer dependency, anything from 16.14 on.',
   },
   {
-    title: 'Auth Just Works',
-    description: 'OAuth 2.0 and long-lived token support with auto-detection.',
+    title: 'MIT Licensed',
+    description: 'Use it in anything, commercial or not.',
   },
 ];
 

--- a/src/services/mockStateTransitions.ts
+++ b/src/services/mockStateTransitions.ts
@@ -86,6 +86,12 @@ export function mockServiceCall(
       ))
       break
 
+    case 'media_player':
+      ({ state: newState, attributes: newAttributes } = mockMediaPlayerService(
+        service, currentState, newAttributes, params
+      ))
+      break
+
     default:
       // For unknown domains, just handle basic toggle/turn_on/turn_off
       ({ state: newState, attributes: newAttributes } = mockBasicService(
@@ -372,6 +378,18 @@ function mockVacuumService(
         attributes: { ...attributes, fan_speed: params.fan_speed as string }
       }
 
+    case 'turn_on':
+      return {
+        state: 'idle',
+        attributes: { ...attributes, status: 'Idle' }
+      }
+
+    case 'turn_off':
+      return {
+        state: 'off',
+        attributes: { ...attributes, status: 'Off' }
+      }
+
     case 'locate':
       return {
         state: currentState,
@@ -383,6 +401,77 @@ function mockVacuumService(
         state: 'cleaning',
         attributes: { ...attributes, status: 'Spot cleaning' }
       }
+
+    default:
+      return { state: currentState, attributes }
+  }
+}
+
+// Mock media-player-specific services
+function mockMediaPlayerService(
+  service: string,
+  currentState: string,
+  attributes: Record<string, unknown>,
+  params: Record<string, unknown>
+): MockStateTransition {
+  switch (service) {
+    case 'media_play':
+      return { state: 'playing', attributes }
+
+    case 'media_pause':
+      return { state: 'paused', attributes }
+
+    case 'media_stop':
+      return { state: 'idle', attributes }
+
+    case 'volume_set':
+      return {
+        state: currentState,
+        attributes: { ...attributes, volume_level: params.volume_level as number }
+      }
+
+    case 'volume_mute':
+      return {
+        state: currentState,
+        attributes: { ...attributes, is_volume_muted: params.is_volume_muted as boolean }
+      }
+
+    case 'media_play_pause':
+      return {
+        state: currentState === 'playing' ? 'paused' : 'playing',
+        attributes
+      }
+
+    case 'toggle':
+      // media_player.toggle is a power toggle in Home Assistant, not play/pause
+      return {
+        state: currentState === 'off' ? 'idle' : 'off',
+        attributes
+      }
+
+    case 'select_source':
+      return {
+        state: currentState,
+        attributes: { ...attributes, source: params.source as string }
+      }
+
+    case 'shuffle_set':
+      return {
+        state: currentState,
+        attributes: { ...attributes, shuffle: params.shuffle as boolean }
+      }
+
+    case 'repeat_set':
+      return {
+        state: currentState,
+        attributes: { ...attributes, repeat: params.repeat as string }
+      }
+
+    case 'turn_on':
+      return { state: 'idle', attributes }
+
+    case 'turn_off':
+      return { state: 'off', attributes }
 
     default:
       return { state: currentState, attributes }

--- a/src/test/utils/__tests__/mockStateTransitions.test.ts
+++ b/src/test/utils/__tests__/mockStateTransitions.test.ts
@@ -438,5 +438,38 @@ describe('mockStateTransitions', () => {
         expect(result.attributes.brightness).toBe(0)
       })
     })
+
+    describe('media_player services', () => {
+      it('pauses and resumes playback', () => {
+        expect(mockServiceCall('media_player', 'media_pause', 'playing', {}, {}).state).toBe('paused')
+        expect(mockServiceCall('media_player', 'media_play', 'paused', {}, {}).state).toBe('playing')
+      })
+
+      it('sets volume without changing playback state', () => {
+        const result = mockServiceCall('media_player', 'volume_set', 'playing', {}, { volume_level: 0.7 })
+        expect(result.state).toBe('playing')
+        expect(result.attributes.volume_level).toBe(0.7)
+      })
+
+      it('treats toggle as a power toggle, not play/pause', () => {
+        // media_player.toggle switches power in Home Assistant
+        expect(mockServiceCall('media_player', 'toggle', 'playing', {}, {}).state).toBe('off')
+        expect(mockServiceCall('media_player', 'toggle', 'off', {}, {}).state).toBe('idle')
+        expect(mockServiceCall('media_player', 'media_play_pause', 'playing', {}, {}).state).toBe('paused')
+      })
+
+      it('selects sources and set shuffle/repeat as attributes', () => {
+        expect(mockServiceCall('media_player', 'select_source', 'playing', {}, { source: 'Spotify' }).attributes.source).toBe('Spotify')
+        expect(mockServiceCall('media_player', 'shuffle_set', 'playing', {}, { shuffle: true }).attributes.shuffle).toBe(true)
+        expect(mockServiceCall('media_player', 'repeat_set', 'playing', {}, { repeat: 'all' }).attributes.repeat).toBe('all')
+      })
+    })
+
+    describe('vacuum power services', () => {
+      it('turns legacy vacuums on and off', () => {
+        expect(mockServiceCall('vacuum', 'turn_on', 'off', {}, {}).state).toBe('idle')
+        expect(mockServiceCall('vacuum', 'turn_off', 'docked', {}, {}).state).toBe('off')
+      })
+    })
   })
 })


### PR DESCRIPTION
Holistic rework of the feature cards per review: Small and Fast, Real-time Updates, and Built-in State Management were the same plumbing claim split three ways. The six cards now each answer a different question: entity coverage (17 types, capability flags, callService), hooks-or-components, headless, live-state-without-plumbing (the one merged plumbing card), auth (incl. server-side transports, previously absent from the homepage), and mock mode (also previously absent). The additionalFeatures row and the README features list follow the same architecture; intro.md's performance section is now mechanics-only so it complements rather than repeats. Every claim source-verified (entity count = 17 files in src/types/entities; peer dep react >=16.14). Supporting fix so the Mock Mode card is fully true: mockStateTransitions gains media player transitions (play/pause/stop/volume/mute/source/shuffle/repeat/power, with toggle correctly a power toggle per HA) and legacy vacuum turn_on/turn_off, with tests. Gate: tsc 0, eslint 0, 1150 tests, docs build green.