### PR TITLE
add gateway guide + runnable example, verified end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Building a Gateway guide plus a runnable gateway example (`examples/transport-gateway`): an allowlisting Node server that owns the Home Assistant token and the matching browser transport
+
 ### Fixed
 - Mock mode now transitions media player state (play/pause/stop, volume, mute, source, shuffle, repeat, power) and legacy vacuum power (`turn_on`/`turn_off`); `media_player.toggle` correctly acts as a power toggle
 

--- a/docs/docs/advanced/building-a-gateway.md
+++ b/docs/docs/advanced/building-a-gateway.md
@@ -1,0 +1,220 @@
+---
+sidebar_position: 4
+---
+
+# Building a Gateway
+
+[External Transports](/docs/advanced/external-transports) covers the contract hass-react expects. This page builds the other half: the gateway server that owns your Home Assistant credential, plus the browser transport that talks to it. The complete runnable version lives in [`examples/transport-gateway`](https://github.com/dlwiest/hass-react/tree/master/examples/transport-gateway).
+
+```text
+Home Assistant  <-- WebSocket, long-lived token -->  gateway (Node)
+gateway  <-- SSE events + HTTP commands -->  browser running hass-react
+```
+
+The browser never sees the token. It sends allowlisted commands to an HTTP endpoint and receives `state_changed` events over one Server-Sent Events stream. hass-react treats the pair as a connection and keeps all of its usual behavior: entity subscriptions, service calls, and reconnection.
+
+## The server
+
+Node 22 or newer, one dependency (`home-assistant-js-websocket`, the same client Home Assistant's frontend uses; Node 22 provides the WebSocket implementation it needs).
+
+Start with the part that makes a gateway worth having, the authorization boundary:
+
+```js
+const ALLOWED_COMMANDS = new Set(['get_states', 'auth/current_user'])
+
+// domain -> allowed services. Extend deliberately, entry by entry.
+const ALLOWED_SERVICES = {
+  light: new Set(['turn_on', 'turn_off', 'toggle']),
+  switch: new Set(['turn_on', 'turn_off', 'toggle']),
+}
+
+// domain -> entities the browser may target. null = any entity in the domain.
+// Scope this to the entities your dashboard actually shows.
+const ALLOWED_ENTITIES = {
+  light: null,
+  switch: null,
+}
+
+function targetedEntities(message) {
+  // Home Assistant accepts the target in either field, as one id or a list.
+  const raw = message.service_data?.entity_id ?? message.target?.entity_id
+  if (raw === undefined) return []
+  return Array.isArray(raw) ? raw : [raw]
+}
+
+function authorize(message) {
+  if (ALLOWED_COMMANDS.has(message.type)) return true
+  if (message.type !== 'call_service') return false
+
+  if (!(ALLOWED_SERVICES[message.domain]?.has(message.service) ?? false)) {
+    return false
+  }
+
+  const allowedEntities = ALLOWED_ENTITIES[message.domain]
+  // A domain allowlisted without an entity decision fails closed.
+  if (allowedEntities === undefined) return false
+  if (allowedEntities === null) return true
+  const targets = targetedEntities(message)
+  return targets.length > 0 && targets.every((id) => allowedEntities.has(id))
+}
+```
+
+Everything the browser may do is enumerated: commands, services per domain, and optionally entities per domain. A request that doesn't match is rejected before it touches Home Assistant, so a compromised or curious client can't call `homeassistant.stop` just because the gateway is reachable. Setting an entity set instead of `null` narrows control to exactly the devices your dashboard shows.
+
+The upstream side is a normal `home-assistant-js-websocket` connection with a long-lived token. One `state_changed` subscription fans out to every connected browser:
+
+```js
+import {createConnection, createLongLivedTokenAuth} from 'home-assistant-js-websocket'
+
+const auth = createLongLivedTokenAuth(process.env.HA_URL, process.env.HA_TOKEN)
+const connection = await createConnection({auth})
+
+const sseClients = new Set()
+
+await connection.subscribeEvents((event) => {
+  const payload = `data: ${JSON.stringify(event)}\n\n`
+  for (const res of sseClients) res.write(payload)
+}, 'state_changed')
+```
+
+Upstream reconnection is free: `createConnection` retries on its own when Home Assistant restarts or drops.
+
+The browser-facing half is two routes on a plain `http` server. `GET /api/events` registers an SSE client; `POST /api/command` parses one JSON message, authorizes it, and forwards it:
+
+```js
+if (req.method === 'POST' && req.url === '/api/command') {
+  const message = JSON.parse(body) // bound the body size before this
+
+  if (!authorize(message)) {
+    res.writeHead(403).end(JSON.stringify({error: `not allowed: ${message.type}`}))
+    return
+  }
+
+  try {
+    const result = await connection.sendMessagePromise(message)
+    res.writeHead(200, {'content-type': 'application/json'})
+    res.end(JSON.stringify(result ?? null))
+  } catch (error) {
+    const ref = crypto.randomUUID()
+    console.error(`command failed [${ref}]`, error)
+    res.writeHead(502).end(JSON.stringify({error: 'upstream command failed', ref}))
+  }
+}
+```
+
+Upstream error details stay in the gateway log. The browser gets a reference id, not Home Assistant internals.
+
+## The client transport
+
+The browser half implements `HATransport` over `fetch` and `EventSource`:
+
+```js
+export function createGatewayTransport(baseUrl) {
+  // connection -> its EventSource, so disconnect() closes the right session.
+  const sessions = new Map()
+
+  return {
+    connect(handlers) {
+      return new Promise((resolve, reject) => {
+        const events = new EventSource(`${baseUrl}/api/events`)
+        const subscribers = new Map()
+        let settled = false
+        let notifiedDisconnect = false
+
+        const connection = {
+          async sendMessagePromise(message) {
+            const response = await fetch(`${baseUrl}/api/command`, {
+              method: 'POST',
+              headers: {'content-type': 'application/json'},
+              body: JSON.stringify(message),
+            })
+            if (!response.ok) throw new Error(`gateway returned ${response.status}`)
+            return response.json()
+          },
+
+          async subscribeEvents(callback, eventType) {
+            const callbacks = subscribers.get(eventType) ?? new Set()
+            callbacks.add(callback)
+            subscribers.set(eventType, callbacks)
+            return () => {
+              callbacks.delete(callback)
+            }
+          },
+        }
+
+        events.onopen = () => {
+          settled = true
+          sessions.set(connection, events)
+          resolve(connection)
+        }
+
+        events.onmessage = ({data}) => {
+          const event = JSON.parse(data)
+          subscribers.get(event.event_type)?.forEach((cb) => cb(event))
+          subscribers.get(undefined)?.forEach((cb) => cb(event))
+        }
+
+        events.onerror = () => {
+          if (!settled) {
+            settled = true
+            events.close()
+            reject(new Error('gateway event stream unavailable'))
+          } else if (!notifiedDisconnect) {
+            notifiedDisconnect = true
+            events.close()
+            sessions.delete(connection)
+            handlers.onDisconnected()
+          }
+        }
+      })
+    },
+
+    disconnect(connection) {
+      sessions.get(connection)?.close()
+      sessions.delete(connection)
+    },
+  }
+}
+```
+
+One design rule matters here: **every `connect()` call builds an independent session.** The EventSource, the subscriber registry, and the settled flags all live inside the call. HAProvider can legitimately run overlapping connect attempts (React StrictMode double-mounts in development, and fast reconnect cycles in production), and it disconnects the attempts it abandons. If sessions share state, a stale attempt's `disconnect()` tears down the live one and the provider hangs in `connecting`. We know because our first draft did exactly that.
+
+The transport also reports a lost stream once and stops. `EventSource` would happily retry on its own, but HAProvider owns reconnection policy; let it call `connect()` again with its own backoff.
+
+## Wiring it up
+
+```jsx
+import { HAProvider } from 'hass-react'
+import { createGatewayTransport } from './gateway-transport'
+
+const transport = createGatewayTransport('http://dashboard.local:8131')
+
+function App() {
+  return (
+    <HAProvider url="http://dashboard.local:8131" transport={transport}>
+      <Dashboard />
+    </HAProvider>
+  )
+}
+```
+
+Create the transport once, outside the component (or memoize it). `url` only resolves relative media URLs in this mode.
+
+## What failure looks like
+
+Verified against the example implementation:
+
+- **Gateway dies:** the transport reports the loss, hass-react shows `disconnected`, then retries `connect()` on its usual backoff (1s, 2s, 4s...). When the gateway returns, the next attempt connects and entity state re-hydrates.
+- **Home Assistant dies:** the gateway's upstream client reconnects on its own. Browsers stay connected to the gateway throughout; commands during the outage fail with 502 and a log reference.
+- **Blocked command:** the gateway returns 403, which surfaces in hass-react as a normal failed service call.
+
+## Hardening beyond the LAN
+
+The example assumes a trusted network, which fits the wall-dashboard case. Before exposing a gateway any wider:
+
+- Put a session in front of both routes (cookie or reverse-proxy auth). Token possession is the whole game.
+- Set `ALLOWED_ORIGIN` to your dashboard's exact origin instead of `*`.
+- Add rate limiting on `/api/command`.
+- If the dashboard shows cameras, proxy `/api/camera_proxy` and `/api/hls/*` too; see [Camera Media](/docs/advanced/external-transports#camera-media).
+
+The [Security Boundary](/docs/advanced/external-transports#security-boundary) section covers the full checklist.

--- a/docs/docs/advanced/external-transports.md
+++ b/docs/docs/advanced/external-transports.md
@@ -106,70 +106,14 @@ Return an unsubscribe function. A transport may multiplex all subscribers over o
 
 `logout` is optional. Use it only if the application gateway maintains a browser session that can be invalidated.
 
-## Minimal Shape
+## Implementing a Transport
 
-This abbreviated example uses one event stream and an HTTP command endpoint:
+A working transport pairs with a gateway server, and the two have to agree on an application protocol. [Building a Gateway](/docs/advanced/building-a-gateway) walks through both halves with a runnable example: an SSE event stream plus an HTTP command endpoint on the server, and the matching `HATransport` in the browser.
 
-```ts
-import type {
-  HAConnection,
-  HATransport,
-  HATransportHandlers,
-} from 'hass-react'
+Two rules matter more than the protocol choice:
 
-export function createGatewayTransport(): HATransport {
-  let events: EventSource | null = null
-  const subscribers = new Map<string | undefined, Set<(event: unknown) => void>>()
-
-  const connection: HAConnection = {
-    async sendMessagePromise<T>(message: Record<string, unknown>): Promise<T> {
-      const response = await fetch('/ha-gateway/command', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(message),
-      })
-
-      if (!response.ok) throw new Error(`Gateway returned ${response.status}`)
-      return response.json() as Promise<T>
-    },
-
-    async subscribeEvents<T>(
-      callback: (event: T) => void,
-      eventType?: string
-    ): Promise<() => void> {
-      const callbacks = subscribers.get(eventType) ?? new Set()
-      callbacks.add(callback as (event: unknown) => void)
-      subscribers.set(eventType, callbacks)
-
-      return () => {
-        callbacks.delete(callback as (event: unknown) => void)
-      }
-    },
-  }
-
-  return {
-    async connect(handlers: HATransportHandlers) {
-      events = new EventSource('/ha-gateway/events')
-
-      events.onmessage = ({ data }) => {
-        const event = JSON.parse(data)
-        subscribers.get(event.event_type)?.forEach((callback) => callback(event))
-        subscribers.get(undefined)?.forEach((callback) => callback(event))
-      }
-
-      events.onerror = () => handlers.onDisconnected()
-      return connection
-    },
-
-    disconnect() {
-      events?.close()
-      events = null
-    },
-  }
-}
-```
-
-Production transports should wait for an explicit ready signal before resolving `connect`, handle duplicate disconnect notifications, and validate response bodies.
+- **Every `connect()` call must build an independent session.** HAProvider can run overlapping connect attempts (React StrictMode double-mounts, fast reconnect cycles) and disconnects the attempts it abandons. If sessions share an event stream or subscriber registry, a stale attempt's `disconnect()` tears down the live session.
+- **Report a lost channel once, then stop.** Resolve `connect()` only when the channel is actually ready, call `handlers.onDisconnected()` a single time on loss, and let HAProvider drive reconnection with its own backoff rather than retrying internally.
 
 ## Camera Media
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -65,6 +65,7 @@ const sidebars: SidebarsConfig = {
         'advanced/multiple-entities',
         'advanced/custom-service-calls',
         'advanced/external-transports',
+        'advanced/building-a-gateway',
       ],
     },
     'error-handling',

--- a/examples/transport-gateway/README.md
+++ b/examples/transport-gateway/README.md
@@ -1,0 +1,31 @@
+# Transport gateway example
+
+A minimal server that owns your Home Assistant credential so the browser never sees it, paired with the hass-react transport that talks to it. The full walkthrough lives in the docs: [Building a Gateway](https://hass-react.com/docs/advanced/building-a-gateway).
+
+## Run it
+
+```bash
+HA_URL=http://homeassistant.local:8123 HA_TOKEN=<long-lived token> node server.mjs
+```
+
+Requires Node 22+ and `home-assistant-js-websocket` (`npm install home-assistant-js-websocket`).
+
+Then in your dashboard:
+
+```jsx
+import { HAProvider } from 'hass-react'
+import { createGatewayTransport } from './client-transport'
+
+const transport = createGatewayTransport('http://127.0.0.1:8131')
+
+<HAProvider url="http://127.0.0.1:8131" transport={transport}>
+  <YourApp />
+</HAProvider>
+```
+
+## What it enforces
+
+- Home Assistant token stays in the gateway process
+- Commands are allowlisted: `get_states`, `auth/current_user`, and `call_service` only for the domain/service pairs in `ALLOWED_SERVICES`
+- Everything else is rejected with a 403
+- Upstream reconnects are handled by `home-assistant-js-websocket`; browser reconnects by `HAProvider`

--- a/examples/transport-gateway/client-transport.js
+++ b/examples/transport-gateway/client-transport.js
@@ -1,0 +1,86 @@
+// The browser half: an HATransport that speaks to server.mjs.
+// Pass it to HAProvider:
+//
+//   const transport = createGatewayTransport('http://127.0.0.1:8131')
+//   <HAProvider url="http://127.0.0.1:8131" transport={transport}>
+//
+// `url` is only used to resolve relative media URLs; commands and events go
+// through the transport.
+//
+// Each connect() call builds an independent session (its own EventSource and
+// subscriber registry). That matters: HAProvider may start a second attempt
+// while an earlier one is still settling (React StrictMode double-mounts,
+// fast reconnects), and it will disconnect the stale attempt. A transport
+// with shared mutable state would let the stale disconnect tear down the
+// live session.
+
+export function createGatewayTransport(baseUrl) {
+  // connection -> its EventSource, so disconnect() closes the right session.
+  const sessions = new Map();
+
+  return {
+    connect(handlers) {
+      return new Promise((resolve, reject) => {
+        const events = new EventSource(`${baseUrl}/api/events`);
+        const subscribers = new Map(); // eventType|undefined -> Set<callback>
+        let settled = false;
+        let notifiedDisconnect = false;
+
+        const connection = {
+          async sendMessagePromise(message) {
+            const response = await fetch(`${baseUrl}/api/command`, {
+              method: 'POST',
+              headers: {'content-type': 'application/json'},
+              body: JSON.stringify(message),
+            });
+            if (!response.ok) {
+              throw new Error(`gateway returned ${response.status}`);
+            }
+            return response.json();
+          },
+
+          async subscribeEvents(callback, eventType) {
+            const callbacks = subscribers.get(eventType) ?? new Set();
+            callbacks.add(callback);
+            subscribers.set(eventType, callbacks);
+            return () => {
+              callbacks.delete(callback);
+            };
+          },
+        };
+
+        events.onopen = () => {
+          settled = true;
+          sessions.set(connection, events);
+          resolve(connection);
+        };
+
+        events.onmessage = ({data}) => {
+          const event = JSON.parse(data);
+          subscribers.get(event.event_type)?.forEach((cb) => cb(event));
+          subscribers.get(undefined)?.forEach((cb) => cb(event));
+        };
+
+        events.onerror = () => {
+          if (!settled) {
+            settled = true;
+            events.close();
+            reject(new Error('gateway event stream unavailable'));
+          } else if (!notifiedDisconnect) {
+            // EventSource retries internally, but HAProvider owns reconnect
+            // policy: report the loss once and let it call connect() again.
+            notifiedDisconnect = true;
+            events.close();
+            sessions.delete(connection);
+            handlers.onDisconnected();
+          }
+        };
+      });
+    },
+
+    disconnect(connection) {
+      sessions.get(connection)?.close();
+      sessions.delete(connection);
+    },
+  };
+}

--- a/examples/transport-gateway/server.mjs
+++ b/examples/transport-gateway/server.mjs
@@ -1,0 +1,156 @@
+// Minimal Home Assistant gateway for hass-react external transports.
+//
+// The gateway owns the Home Assistant credential and the upstream WebSocket.
+// Browsers never see either: they talk to this server over one SSE stream
+// (events) and one HTTP endpoint (commands), through the matching client
+// transport in client-transport.js.
+//
+// Run:  HA_URL=http://homeassistant.local:8123 HA_TOKEN=<long-lived token> node server.mjs
+// Node 22+ (native WebSocket). The only dependency is home-assistant-js-websocket.
+
+import http from 'node:http';
+import crypto from 'node:crypto';
+import {
+  createConnection,
+  createLongLivedTokenAuth,
+} from 'home-assistant-js-websocket';
+
+const HA_URL = process.env.HA_URL ?? 'http://homeassistant.local:8123';
+const HA_TOKEN = process.env.HA_TOKEN;
+const PORT = Number(process.env.PORT ?? 8131);
+// Lock this down to your dashboard's origin in anything beyond LAN use.
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? '*';
+
+if (!HA_TOKEN) {
+  console.error('HA_TOKEN is required (Home Assistant profile -> long-lived access tokens)');
+  process.exit(1);
+}
+
+// -- The authorization boundary --------------------------------------------
+// Everything the browser may do is enumerated here. A request that does not
+// match is rejected; the gateway never forwards arbitrary commands.
+
+const ALLOWED_COMMANDS = new Set(['get_states', 'auth/current_user']);
+
+// domain -> allowed services. Extend deliberately, entry by entry.
+const ALLOWED_SERVICES = {
+  light: new Set(['turn_on', 'turn_off', 'toggle']),
+  switch: new Set(['turn_on', 'turn_off', 'toggle']),
+};
+
+// domain -> entities the browser may target. null = any entity in the domain.
+// Scope this to the entities your dashboard actually shows.
+const ALLOWED_ENTITIES = {
+  light: null,
+  switch: null,
+};
+
+function targetedEntities(message) {
+  // Home Assistant accepts the target in either field, as one id or a list.
+  const raw = message.service_data?.entity_id ?? message.target?.entity_id;
+  if (raw === undefined) return [];
+  return Array.isArray(raw) ? raw : [raw];
+}
+
+function authorize(message) {
+  if (ALLOWED_COMMANDS.has(message.type)) return true;
+  if (message.type !== 'call_service') return false;
+
+  if (!(ALLOWED_SERVICES[message.domain]?.has(message.service) ?? false)) {
+    return false;
+  }
+
+  const allowedEntities = ALLOWED_ENTITIES[message.domain];
+  // Missing entry means the domain was allowlisted without an entity scope
+  // decision. Fail closed rather than throwing.
+  if (allowedEntities === undefined) return false;
+  if (allowedEntities === null) return true;
+  const targets = targetedEntities(message);
+  return targets.length > 0 && targets.every((id) => allowedEntities.has(id));
+}
+
+// -- Upstream connection ----------------------------------------------------
+
+const auth = createLongLivedTokenAuth(HA_URL, HA_TOKEN);
+const connection = await createConnection({auth});
+console.log(`connected to Home Assistant at ${HA_URL}`);
+
+// One upstream subscription; fan events out to every connected browser.
+const sseClients = new Set();
+
+await connection.subscribeEvents((event) => {
+  const payload = `data: ${JSON.stringify(event)}\n\n`;
+  for (const res of sseClients) res.write(payload);
+}, 'state_changed');
+
+connection.addEventListener('disconnected', () => {
+  console.warn('upstream disconnected; home-assistant-js-websocket will reconnect');
+});
+
+// -- Browser-facing server --------------------------------------------------
+
+const server = http.createServer(async (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
+  res.setHeader('Access-Control-Allow-Headers', 'content-type');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204).end();
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/api/events') {
+    res.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    });
+    res.write(': connected\n\n');
+    sseClients.add(res);
+    req.on('close', () => sseClients.delete(res));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/command') {
+    let body = '';
+    req.setEncoding('utf8');
+    for await (const chunk of req) {
+      body += chunk;
+      if (body.length > 64 * 1024) {
+        res.writeHead(413).end();
+        return;
+      }
+    }
+
+    let message;
+    try {
+      message = JSON.parse(body);
+    } catch {
+      res.writeHead(400).end(JSON.stringify({error: 'invalid JSON'}));
+      return;
+    }
+
+    if (!authorize(message)) {
+      res.writeHead(403).end(JSON.stringify({error: `not allowed: ${message.type}`}));
+      return;
+    }
+
+    try {
+      const result = await connection.sendMessagePromise(message);
+      res.writeHead(200, {'content-type': 'application/json'});
+      res.end(JSON.stringify(result ?? null));
+    } catch (error) {
+      const id = crypto.randomUUID();
+      console.error(`command failed [${id}]`, error);
+      res.writeHead(502, {'content-type': 'application/json'});
+      // Error details stay in the gateway log; the browser gets a reference.
+      res.end(JSON.stringify({error: 'upstream command failed', ref: id}));
+    }
+    return;
+  }
+
+  res.writeHead(404).end();
+});
+
+server.listen(PORT, () => {
+  console.log(`gateway listening on http://127.0.0.1:${PORT}`);
+});

--- a/src/providers/__tests__/HAProvider.externalTransport.test.tsx
+++ b/src/providers/__tests__/HAProvider.externalTransport.test.tsx
@@ -358,4 +358,50 @@ describe('HAProvider external transport', () => {
     expect(screen.getByTestId('error')).toHaveTextContent('Gateway unavailable')
     expect(screen.getByTestId('connected')).toHaveTextContent('false')
   })
+
+  it('keeps retrying through repeated connect failures and recovers when the gateway returns', async () => {
+    vi.useFakeTimers()
+    const fixture = createExternalFixture()
+    const realConnect = fixture.transport.connect as ReturnType<typeof vi.fn>
+    const originalImpl = realConnect.getMockImplementation()!
+    // Gateway is down for the first 6 attempts (initial + 5 retries), then back.
+    let attempts = 0
+    realConnect.mockImplementation(async (nextHandlers: HATransportHandlers) => {
+      attempts += 1
+      if (attempts <= 6) {
+        throw new Error('gateway event stream unavailable')
+      }
+      return originalImpl(nextHandlers)
+    })
+
+    const rendered = render(
+      <HAProvider url="http://gateway.local" transport={fixture.transport}>
+        <ConnectionHarness />
+      </HAProvider>
+    )
+
+    try {
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(screen.getByTestId('state')).toHaveTextContent('error')
+
+      // Backoff schedule: 1s, 2s, 4s, 8s, 16s, 30s (cap), 30s...
+      // Advance stepwise: each act() boundary lets React flush the state
+      // update and re-arm the next retry effect (a single big jump would
+      // never yield to React between timers).
+      for (let step = 0; step < 60 && attempts < 7; step++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2_000)
+        })
+      }
+
+      expect(attempts).toBeGreaterThanOrEqual(7)
+      expect(screen.getByTestId('state')).toHaveTextContent('connected')
+      expect(screen.getByTestId('connected')).toHaveTextContent('true')
+    } finally {
+      rendered.unmount()
+      vi.useRealTimers()
+    }
+  })
 })


### PR DESCRIPTION
The external-transports page documented the browser contract but left the gateway (the hard 80%) as an exercise. This adds docs/advanced/building-a-gateway plus examples/transport-gateway: a Node 22 server (only dep: home-assistant-js-websocket, running on the native WebSocket) that owns the HA token, allowlists commands per domain/service/entity (fail-closed, checks both service_data.entity_id and target.entity_id incl. arrays), fans state_changed out over SSE, and the matching per-session browser transport. Every claim on the page was exercised before being written: full browser E2E against a protocol-faithful HA stand-in (hydration, service round-trip, 403 allowlist denial surfacing as a typed error, and a full outage/recovery cycle with 1/2/4/8s backoff observed and reconnection confirmed). Two byproducts: the Minimal Shape snippet on external-transports.md taught a shared-EventSource transport that breaks under StrictMode/reconnect overlap (a stale disconnect kills the live session) and is replaced by two transport design rules + a link; and a new unit test pins that HAProvider keeps retrying transport connect failures and recovers, which also documents a fake-timer testing trap (single big advanceTimersByTimeAsync never lets React re-arm effects). Gate: 1151 tests, docs build green.