### PR TITLE
restructure gateway guide to build order + download links + literal snippets

### DIFF
--- a/docs/docs/advanced/building-a-gateway.md
+++ b/docs/docs/advanced/building-a-gateway.md
@@ -4,20 +4,120 @@ sidebar_position: 4
 
 # Building a Gateway
 
-[External Transports](/docs/advanced/external-transports) covers the contract hass-react expects. This page builds the other half: the gateway server that owns your Home Assistant credential, plus the browser transport that talks to it. The complete runnable version lives in [`examples/transport-gateway`](https://github.com/dlwiest/hass-react/tree/master/examples/transport-gateway).
+[External Transports](/docs/advanced/external-transports) covers the contract hass-react expects. This page builds the other half: the gateway server that owns your Home Assistant credential, plus the browser transport that talks to it.
 
 ```text
 Home Assistant  <-- WebSocket, long-lived token -->  gateway (Node)
 gateway  <-- SSE events + HTTP commands -->  browser running hass-react
 ```
 
-The browser never sees the token. It sends allowlisted commands to an HTTP endpoint and receives `state_changed` events over one Server-Sent Events stream. hass-react treats the pair as a connection and keeps all of its usual behavior: entity subscriptions, service calls, and reconnection.
+The browser never sees the token. It sends commands to an HTTP endpoint and receives `state_changed` events over one Server-Sent Events stream. hass-react treats the pair as a connection and keeps all of its usual behavior: entity subscriptions, service calls, and reconnection.
 
-## The server
+## Running the example
 
-Node 22 or newer, one dependency (`home-assistant-js-websocket`, the same client Home Assistant's frontend uses; Node 22 provides the WebSocket implementation it needs).
+The complete server is about 130 lines and lives in [`examples/transport-gateway`](https://github.com/dlwiest/hass-react/tree/master/examples/transport-gateway). Grab both halves directly:
 
-Start with the part that makes a gateway worth having, the authorization boundary:
+```bash
+curl -O https://raw.githubusercontent.com/dlwiest/hass-react/master/examples/transport-gateway/server.mjs
+curl -O https://raw.githubusercontent.com/dlwiest/hass-react/master/examples/transport-gateway/client-transport.js
+```
+
+Node 22 or newer, one dependency:
+
+```bash
+npm install home-assistant-js-websocket
+HA_URL=http://homeassistant.local:8123 HA_TOKEN=<long-lived token> node server.mjs
+```
+
+The rest of this page walks through how it's put together, in the order you'd write it.
+
+## Connecting upstream
+
+The gateway talks to Home Assistant with `home-assistant-js-websocket`, the same client Home Assistant's own frontend uses (Node 22 provides the WebSocket implementation it needs). A long-lived token from your profile page authenticates it:
+
+```js
+import {
+  createConnection,
+  createLongLivedTokenAuth,
+} from 'home-assistant-js-websocket'
+
+const HA_URL = process.env.HA_URL ?? 'http://homeassistant.local:8123'
+const HA_TOKEN = process.env.HA_TOKEN
+
+const auth = createLongLivedTokenAuth(HA_URL, HA_TOKEN)
+const connection = await createConnection({auth})
+```
+
+Upstream reconnection is free: `createConnection` retries on its own when Home Assistant restarts or drops.
+
+The gateway holds exactly one upstream subscription and fans events out to every connected browser:
+
+```js
+const sseClients = new Set()
+
+await connection.subscribeEvents((event) => {
+  const payload = `data: ${JSON.stringify(event)}\n\n`
+  for (const res of sseClients) res.write(payload)
+}, 'state_changed')
+```
+
+## The browser-facing routes
+
+Two routes on a plain `http` server. `GET /api/events` registers a browser for the event stream:
+
+```js
+if (req.method === 'GET' && req.url === '/api/events') {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  })
+  res.write(': connected\n\n')
+  sseClients.add(res)
+  req.on('close', () => sseClients.delete(res))
+  return
+}
+```
+
+`POST /api/command` parses one JSON message and forwards it upstream:
+
+```js
+if (req.method === 'POST' && req.url === '/api/command') {
+  // ...read the request body with a size bound (see the full example)...
+
+  let message
+  try {
+    message = JSON.parse(body)
+  } catch {
+    res.writeHead(400).end(JSON.stringify({error: 'invalid JSON'}))
+    return
+  }
+
+  if (!authorize(message)) {
+    res.writeHead(403).end(JSON.stringify({error: `not allowed: ${message.type}`}))
+    return
+  }
+
+  try {
+    const result = await connection.sendMessagePromise(message)
+    res.writeHead(200, {'content-type': 'application/json'})
+    res.end(JSON.stringify(result ?? null))
+  } catch (error) {
+    const id = crypto.randomUUID()
+    console.error(`command failed [${id}]`, error)
+    res.writeHead(502, {'content-type': 'application/json'})
+    // Error details stay in the gateway log; the browser gets a reference.
+    res.end(JSON.stringify({error: 'upstream command failed', ref: id}))
+  }
+  return
+}
+```
+
+Two details to keep: upstream error text stays in the gateway log and the browser gets a reference id, not Home Assistant internals. And that `authorize` call is load-bearing, because everything else on this page is an open proxy.
+
+## The authorization boundary
+
+Without `authorize`, any client that can reach the gateway can send any command to Home Assistant: unlock doors, disarm the alarm, call `homeassistant.stop`. The gateway's job is to narrow that to what your dashboard actually does. Enumerate it:
 
 ```js
 const ALLOWED_COMMANDS = new Set(['get_states', 'auth/current_user'])
@@ -59,50 +159,7 @@ function authorize(message) {
 }
 ```
 
-Everything the browser may do is enumerated: commands, services per domain, and optionally entities per domain. A request that doesn't match is rejected before it touches Home Assistant, so a compromised or curious client can't call `homeassistant.stop` just because the gateway is reachable. Setting an entity set instead of `null` narrows control to exactly the devices your dashboard shows.
-
-The upstream side is a normal `home-assistant-js-websocket` connection with a long-lived token. One `state_changed` subscription fans out to every connected browser:
-
-```js
-import {createConnection, createLongLivedTokenAuth} from 'home-assistant-js-websocket'
-
-const auth = createLongLivedTokenAuth(process.env.HA_URL, process.env.HA_TOKEN)
-const connection = await createConnection({auth})
-
-const sseClients = new Set()
-
-await connection.subscribeEvents((event) => {
-  const payload = `data: ${JSON.stringify(event)}\n\n`
-  for (const res of sseClients) res.write(payload)
-}, 'state_changed')
-```
-
-Upstream reconnection is free: `createConnection` retries on its own when Home Assistant restarts or drops.
-
-The browser-facing half is two routes on a plain `http` server. `GET /api/events` registers an SSE client; `POST /api/command` parses one JSON message, authorizes it, and forwards it:
-
-```js
-if (req.method === 'POST' && req.url === '/api/command') {
-  const message = JSON.parse(body) // bound the body size before this
-
-  if (!authorize(message)) {
-    res.writeHead(403).end(JSON.stringify({error: `not allowed: ${message.type}`}))
-    return
-  }
-
-  try {
-    const result = await connection.sendMessagePromise(message)
-    res.writeHead(200, {'content-type': 'application/json'})
-    res.end(JSON.stringify(result ?? null))
-  } catch (error) {
-    const ref = crypto.randomUUID()
-    console.error(`command failed [${ref}]`, error)
-    res.writeHead(502).end(JSON.stringify({error: 'upstream command failed', ref}))
-  }
-}
-```
-
-Upstream error details stay in the gateway log. The browser gets a reference id, not Home Assistant internals.
+A request that doesn't match is rejected before it touches Home Assistant. Setting an entity set instead of `null` narrows control to exactly the devices your dashboard shows.
 
 ## The client transport
 
@@ -117,7 +174,7 @@ export function createGatewayTransport(baseUrl) {
     connect(handlers) {
       return new Promise((resolve, reject) => {
         const events = new EventSource(`${baseUrl}/api/events`)
-        const subscribers = new Map()
+        const subscribers = new Map() // eventType|undefined -> Set<callback>
         let settled = false
         let notifiedDisconnect = false
 
@@ -128,7 +185,9 @@ export function createGatewayTransport(baseUrl) {
               headers: {'content-type': 'application/json'},
               body: JSON.stringify(message),
             })
-            if (!response.ok) throw new Error(`gateway returned ${response.status}`)
+            if (!response.ok) {
+              throw new Error(`gateway returned ${response.status}`)
+            }
             return response.json()
           },
 

--- a/examples/transport-gateway/client-transport.js
+++ b/examples/transport-gateway/client-transport.js
@@ -16,15 +16,15 @@
 
 export function createGatewayTransport(baseUrl) {
   // connection -> its EventSource, so disconnect() closes the right session.
-  const sessions = new Map();
+  const sessions = new Map()
 
   return {
     connect(handlers) {
       return new Promise((resolve, reject) => {
-        const events = new EventSource(`${baseUrl}/api/events`);
-        const subscribers = new Map(); // eventType|undefined -> Set<callback>
-        let settled = false;
-        let notifiedDisconnect = false;
+        const events = new EventSource(`${baseUrl}/api/events`)
+        const subscribers = new Map() // eventType|undefined -> Set<callback>
+        let settled = false
+        let notifiedDisconnect = false
 
         const connection = {
           async sendMessagePromise(message) {
@@ -32,55 +32,55 @@ export function createGatewayTransport(baseUrl) {
               method: 'POST',
               headers: {'content-type': 'application/json'},
               body: JSON.stringify(message),
-            });
+            })
             if (!response.ok) {
-              throw new Error(`gateway returned ${response.status}`);
+              throw new Error(`gateway returned ${response.status}`)
             }
-            return response.json();
+            return response.json()
           },
 
           async subscribeEvents(callback, eventType) {
-            const callbacks = subscribers.get(eventType) ?? new Set();
-            callbacks.add(callback);
-            subscribers.set(eventType, callbacks);
+            const callbacks = subscribers.get(eventType) ?? new Set()
+            callbacks.add(callback)
+            subscribers.set(eventType, callbacks)
             return () => {
-              callbacks.delete(callback);
-            };
+              callbacks.delete(callback)
+            }
           },
-        };
+        }
 
         events.onopen = () => {
-          settled = true;
-          sessions.set(connection, events);
-          resolve(connection);
-        };
+          settled = true
+          sessions.set(connection, events)
+          resolve(connection)
+        }
 
         events.onmessage = ({data}) => {
-          const event = JSON.parse(data);
-          subscribers.get(event.event_type)?.forEach((cb) => cb(event));
-          subscribers.get(undefined)?.forEach((cb) => cb(event));
-        };
+          const event = JSON.parse(data)
+          subscribers.get(event.event_type)?.forEach((cb) => cb(event))
+          subscribers.get(undefined)?.forEach((cb) => cb(event))
+        }
 
         events.onerror = () => {
           if (!settled) {
-            settled = true;
-            events.close();
-            reject(new Error('gateway event stream unavailable'));
+            settled = true
+            events.close()
+            reject(new Error('gateway event stream unavailable'))
           } else if (!notifiedDisconnect) {
             // EventSource retries internally, but HAProvider owns reconnect
             // policy: report the loss once and let it call connect() again.
-            notifiedDisconnect = true;
-            events.close();
-            sessions.delete(connection);
-            handlers.onDisconnected();
+            notifiedDisconnect = true
+            events.close()
+            sessions.delete(connection)
+            handlers.onDisconnected()
           }
-        };
-      });
+        }
+      })
     },
 
     disconnect(connection) {
-      sessions.get(connection)?.close();
-      sessions.delete(connection);
+      sessions.get(connection)?.close()
+      sessions.delete(connection)
     },
-  };
+  }
 }

--- a/examples/transport-gateway/server.mjs
+++ b/examples/transport-gateway/server.mjs
@@ -8,94 +8,94 @@
 // Run:  HA_URL=http://homeassistant.local:8123 HA_TOKEN=<long-lived token> node server.mjs
 // Node 22+ (native WebSocket). The only dependency is home-assistant-js-websocket.
 
-import http from 'node:http';
-import crypto from 'node:crypto';
+import http from 'node:http'
+import crypto from 'node:crypto'
 import {
   createConnection,
   createLongLivedTokenAuth,
-} from 'home-assistant-js-websocket';
+} from 'home-assistant-js-websocket'
 
-const HA_URL = process.env.HA_URL ?? 'http://homeassistant.local:8123';
-const HA_TOKEN = process.env.HA_TOKEN;
-const PORT = Number(process.env.PORT ?? 8131);
+const HA_URL = process.env.HA_URL ?? 'http://homeassistant.local:8123'
+const HA_TOKEN = process.env.HA_TOKEN
+const PORT = Number(process.env.PORT ?? 8131)
 // Lock this down to your dashboard's origin in anything beyond LAN use.
-const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? '*';
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? '*'
 
 if (!HA_TOKEN) {
-  console.error('HA_TOKEN is required (Home Assistant profile -> long-lived access tokens)');
-  process.exit(1);
+  console.error('HA_TOKEN is required (Home Assistant profile -> long-lived access tokens)')
+  process.exit(1)
 }
 
 // -- The authorization boundary --------------------------------------------
 // Everything the browser may do is enumerated here. A request that does not
 // match is rejected; the gateway never forwards arbitrary commands.
 
-const ALLOWED_COMMANDS = new Set(['get_states', 'auth/current_user']);
+const ALLOWED_COMMANDS = new Set(['get_states', 'auth/current_user'])
 
 // domain -> allowed services. Extend deliberately, entry by entry.
 const ALLOWED_SERVICES = {
   light: new Set(['turn_on', 'turn_off', 'toggle']),
   switch: new Set(['turn_on', 'turn_off', 'toggle']),
-};
+}
 
 // domain -> entities the browser may target. null = any entity in the domain.
 // Scope this to the entities your dashboard actually shows.
 const ALLOWED_ENTITIES = {
   light: null,
   switch: null,
-};
+}
 
 function targetedEntities(message) {
   // Home Assistant accepts the target in either field, as one id or a list.
-  const raw = message.service_data?.entity_id ?? message.target?.entity_id;
-  if (raw === undefined) return [];
-  return Array.isArray(raw) ? raw : [raw];
+  const raw = message.service_data?.entity_id ?? message.target?.entity_id
+  if (raw === undefined) return []
+  return Array.isArray(raw) ? raw : [raw]
 }
 
 function authorize(message) {
-  if (ALLOWED_COMMANDS.has(message.type)) return true;
-  if (message.type !== 'call_service') return false;
+  if (ALLOWED_COMMANDS.has(message.type)) return true
+  if (message.type !== 'call_service') return false
 
   if (!(ALLOWED_SERVICES[message.domain]?.has(message.service) ?? false)) {
-    return false;
+    return false
   }
 
-  const allowedEntities = ALLOWED_ENTITIES[message.domain];
+  const allowedEntities = ALLOWED_ENTITIES[message.domain]
   // Missing entry means the domain was allowlisted without an entity scope
   // decision. Fail closed rather than throwing.
-  if (allowedEntities === undefined) return false;
-  if (allowedEntities === null) return true;
-  const targets = targetedEntities(message);
-  return targets.length > 0 && targets.every((id) => allowedEntities.has(id));
+  if (allowedEntities === undefined) return false
+  if (allowedEntities === null) return true
+  const targets = targetedEntities(message)
+  return targets.length > 0 && targets.every((id) => allowedEntities.has(id))
 }
 
 // -- Upstream connection ----------------------------------------------------
 
-const auth = createLongLivedTokenAuth(HA_URL, HA_TOKEN);
-const connection = await createConnection({auth});
-console.log(`connected to Home Assistant at ${HA_URL}`);
+const auth = createLongLivedTokenAuth(HA_URL, HA_TOKEN)
+const connection = await createConnection({auth})
+console.log(`connected to Home Assistant at ${HA_URL}`)
 
 // One upstream subscription; fan events out to every connected browser.
-const sseClients = new Set();
+const sseClients = new Set()
 
 await connection.subscribeEvents((event) => {
-  const payload = `data: ${JSON.stringify(event)}\n\n`;
-  for (const res of sseClients) res.write(payload);
-}, 'state_changed');
+  const payload = `data: ${JSON.stringify(event)}\n\n`
+  for (const res of sseClients) res.write(payload)
+}, 'state_changed')
 
 connection.addEventListener('disconnected', () => {
-  console.warn('upstream disconnected; home-assistant-js-websocket will reconnect');
-});
+  console.warn('upstream disconnected; home-assistant-js-websocket will reconnect')
+})
 
 // -- Browser-facing server --------------------------------------------------
 
 const server = http.createServer(async (req, res) => {
-  res.setHeader('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
-  res.setHeader('Access-Control-Allow-Headers', 'content-type');
+  res.setHeader('Access-Control-Allow-Origin', ALLOWED_ORIGIN)
+  res.setHeader('Access-Control-Allow-Headers', 'content-type')
 
   if (req.method === 'OPTIONS') {
-    res.writeHead(204).end();
-    return;
+    res.writeHead(204).end()
+    return
   }
 
   if (req.method === 'GET' && req.url === '/api/events') {
@@ -103,54 +103,54 @@ const server = http.createServer(async (req, res) => {
       'content-type': 'text/event-stream',
       'cache-control': 'no-cache',
       connection: 'keep-alive',
-    });
-    res.write(': connected\n\n');
-    sseClients.add(res);
-    req.on('close', () => sseClients.delete(res));
-    return;
+    })
+    res.write(': connected\n\n')
+    sseClients.add(res)
+    req.on('close', () => sseClients.delete(res))
+    return
   }
 
   if (req.method === 'POST' && req.url === '/api/command') {
-    let body = '';
-    req.setEncoding('utf8');
+    let body = ''
+    req.setEncoding('utf8')
     for await (const chunk of req) {
-      body += chunk;
+      body += chunk
       if (body.length > 64 * 1024) {
-        res.writeHead(413).end();
-        return;
+        res.writeHead(413).end()
+        return
       }
     }
 
-    let message;
+    let message
     try {
-      message = JSON.parse(body);
+      message = JSON.parse(body)
     } catch {
-      res.writeHead(400).end(JSON.stringify({error: 'invalid JSON'}));
-      return;
+      res.writeHead(400).end(JSON.stringify({error: 'invalid JSON'}))
+      return
     }
 
     if (!authorize(message)) {
-      res.writeHead(403).end(JSON.stringify({error: `not allowed: ${message.type}`}));
-      return;
+      res.writeHead(403).end(JSON.stringify({error: `not allowed: ${message.type}`}))
+      return
     }
 
     try {
-      const result = await connection.sendMessagePromise(message);
-      res.writeHead(200, {'content-type': 'application/json'});
-      res.end(JSON.stringify(result ?? null));
+      const result = await connection.sendMessagePromise(message)
+      res.writeHead(200, {'content-type': 'application/json'})
+      res.end(JSON.stringify(result ?? null))
     } catch (error) {
-      const id = crypto.randomUUID();
-      console.error(`command failed [${id}]`, error);
-      res.writeHead(502, {'content-type': 'application/json'});
+      const id = crypto.randomUUID()
+      console.error(`command failed [${id}]`, error)
+      res.writeHead(502, {'content-type': 'application/json'})
       // Error details stay in the gateway log; the browser gets a reference.
-      res.end(JSON.stringify({error: 'upstream command failed', ref: id}));
+      res.end(JSON.stringify({error: 'upstream command failed', ref: id}))
     }
-    return;
+    return
   }
 
-  res.writeHead(404).end();
-});
+  res.writeHead(404).end()
+})
 
 server.listen(PORT, () => {
-  console.log(`gateway listening on http://127.0.0.1:${PORT}`);
-});
+  console.log(`gateway listening on http://127.0.0.1:${PORT}`)
+})


### PR DESCRIPTION
Review feedback: the guide opened with the authorize() function, a code block from the middle of a file nobody had seen. Restructured to the order you'd actually build it: run the example (now with curl download links for both files), connect upstream, the two browser-facing routes, THEN the authorization boundary as the step that turns an open proxy into a gateway. Also aligned every doc snippet to be a literal line-for-line extract of the example files (checked mechanically), normalized the example files to the repo's semicolon-free style, and re-ran the full browser E2E incl. the outage/recovery cycle against the final bytes.